### PR TITLE
[IMP] Dotted notation now usable on recordset

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ from otools_rpc.external_api import Environment
 url = "http://localhost:8069/"
 username = "admin"
 password = "admin"
-master_password = "adminadmin"
+db = "my_odoo"
 
 # Create an instance of the environment
-env = Environment(url, username, password, db='my_odoo')
+env = Environment(url, username, password, db=db)
 env = env.with_context(lang='en_US')
 print(env)
 
@@ -77,7 +77,6 @@ print("Created invoice:", invoice_id)
 
 # Posting the invoice
 invoice_id.action_post()
-
 ```
 
 ### DBManager

--- a/otools_rpc/external_api/environment.py
+++ b/otools_rpc/external_api/environment.py
@@ -50,21 +50,18 @@ class Environment(dict):
         self.requests = list()
         self._context = frozendict()
 
-        # Todo: make it an object
+        # Todo: make it an object (RecordSet)
         self.user = None
 
         # --------------------------------------------
         #                   CACHE
         # --------------------------------------------
-        if not cache_enabled:
-            cache_default_expiration = 0
-        elif cache_no_expiration:
-            cache_default_expiration = 31_536_000       # 1 year for fun (365 * 24 * 60 * 60)
-
         # Cache will always be created even if we don't use it to store infos
         # It is used for helpers like field_exists()
-        self.cache = Cache(self, cache_default_expiration)
         self.cache_enabled = cache_enabled
+        self.cache_no_expiration = cache_no_expiration
+        self.cache_default_expiration = cache_default_expiration
+        self.cache = Cache(self)
 
 
         if auto_auth:
@@ -98,6 +95,14 @@ class Environment(dict):
     def requests_count(self):
         return len(self.requests)
 
+    @property
+    def cache_expiration(self):
+        if not self.cache_enabled:
+            return 0
+        elif self.cache_no_expiration:
+            return 31_536_000       # 1 year for fun (365 * 24 * 60 * 60)
+        else:
+            return self.cache_default_expiration
 
     # --------------------------------------------
     #                   PUBLIC

--- a/otools_rpc/external_api/utils.py
+++ b/otools_rpc/external_api/utils.py
@@ -17,3 +17,6 @@ def is_magic_number(val: Any) -> bool:
 def is_magic_number_list(vals_list: Any) -> bool:
     return isinstance(vals_list, list) and all(is_magic_number(v) for v in vals_list)
 
+
+def is_relational_field(field_type: str) -> bool:
+    return field_type in ['many2one', 'one2many', 'many2many']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="otools-rpc",
-    version="0.4.5",
+    version="0.5.0",
     description="A tool to interact with Odoo's external API.",
     packages=find_packages(exclude=["tests"]),
     long_description=long_description,


### PR DESCRIPTION
It will use the mapped() method that has been greatly improved

- Cache configuration is now made in the Environment to avoid multiple configurable classes
- Add a warning if cache default expiration is too low
- Fix a bug when Odoo API returned False for a relational field (would create a recordset with id=False)
- Fix some cases when context was not passed correctly


close #38 #39 